### PR TITLE
Some minor label positioning fixes

### DIFF
--- a/src/scales/scale.category.js
+++ b/src/scales/scale.category.js
@@ -303,7 +303,7 @@
 
                         if (this.options.labels.show) {
                             this.ctx.save();
-                            this.ctx.translate(xLabelValue, (isRotated) ? this.top + 12 : this.top + 8);
+                            this.ctx.translate(xLabelValue, (isRotated) ? this.top + 12 + this.options.labels.padding : this.top + this.options.labels.padding);
                             this.ctx.rotate(helpers.toRadians(this.labelRotation) * -1);
                             this.ctx.font = this.font;
                             this.ctx.textAlign = (isRotated) ? "right" : "center";

--- a/src/scales/scale.category.js
+++ b/src/scales/scale.category.js
@@ -147,7 +147,7 @@
                 var datasetWidth = Math.floor(this.getPixelForValue(0, 1) - this.getPixelForValue(0, 0)) - 6;
 
                 //Max label rotation can be set or default to 90 - also act as a loop counter
-                while (this.labelWidth > datasetWidth && this.labelRotation <= this.options.labels.maxRotation) {
+                while (this.labelWidth > datasetWidth && this.labelRotation < this.options.labels.maxRotation) {
                     cosRotation = Math.cos(helpers.toRadians(this.labelRotation));
                     sinRotation = Math.sin(helpers.toRadians(this.labelRotation));
 


### PR DESCRIPTION
- Checking for <= maxRotation results in a labelRotation of 1 if maxRotation is 0, which doesn't make any sense (and also causes the text to be right aligned not centred).
- Quick patch for x-axis padding too, as it currently has no affect on x-axis labels which is a bit strange to leave out.
